### PR TITLE
Added message field to Violation DTO to be more aligned with industry standards

### DIFF
--- a/integration-test/src/test/java/com/tietoevry/quarkus/resteasy/problem/JavaxMappersIT.java
+++ b/integration-test/src/test/java/com/tietoevry/quarkus/resteasy/problem/JavaxMappersIT.java
@@ -45,7 +45,7 @@ class JavaxMappersIT {
                 .body("status", equalTo(BAD_REQUEST.getStatusCode()))
                 .body("violations", hasSize(1))
                 .body("violations[0].field", equalTo("key"))
-                .body("violations[0].error", equalTo("must be greater than or equal to 15"))
+                .body("violations[0].message", equalTo("must be greater than or equal to 15"))
                 .body("stacktrace", nullValue());
     }
 

--- a/runtime/src/main/java/com/tietoevry/quarkus/resteasy/problem/javax/ConstraintViolationExceptionMapper.java
+++ b/runtime/src/main/java/com/tietoevry/quarkus/resteasy/problem/javax/ConstraintViolationExceptionMapper.java
@@ -37,10 +37,10 @@ public final class ConstraintViolationExceptionMapper extends ExceptionMapperBas
     private Violation toViolation(ConstraintViolation<?> constraintViolation) {
         return new Violation(
                 constraintViolation.getMessage(),
-                dropMethodNameAndArgumentPostionFromPath(constraintViolation.getPropertyPath()));
+                dropMethodNameAndArgumentPositionFromPath(constraintViolation.getPropertyPath()));
     }
 
-    private String dropMethodNameAndArgumentPostionFromPath(Path propertyPath) {
+    private String dropMethodNameAndArgumentPositionFromPath(Path propertyPath) {
         Iterator<Path.Node> propertyPathIterator = propertyPath.iterator();
         propertyPathIterator.next();
         propertyPathIterator.next();

--- a/runtime/src/main/java/com/tietoevry/quarkus/resteasy/problem/javax/Violation.java
+++ b/runtime/src/main/java/com/tietoevry/quarkus/resteasy/problem/javax/Violation.java
@@ -2,18 +2,26 @@ package com.tietoevry.quarkus.resteasy.problem.javax;
 
 public final class Violation {
 
-    public final String error;
     public final String field;
+    public final String message;
 
-    public Violation(String error, String field) {
-        this.error = error;
+    /**
+     * Deprecated, use message instead.
+     */
+    @Deprecated
+    public final String error;
+
+    public Violation(String message, String field) {
         this.field = field;
+        this.message = message;
+
+        this.error = message;
     }
 
     @Override
     public String toString() {
         return "Violation{" +
-                "error='" + error + '\'' +
+                "message='" + message + '\'' +
                 ", field='" + field + '\'' +
                 '}';
     }

--- a/runtime/src/test/java/com/tietoevry/quarkus/resteasy/problem/postprocessing/ProblemLoggerTest.java
+++ b/runtime/src/test/java/com/tietoevry/quarkus/resteasy/problem/postprocessing/ProblemLoggerTest.java
@@ -53,7 +53,7 @@ class ProblemLoggerTest {
         assertThat(capturedInfoMessage())
                 .contains(
                         "custom-field=\"123\"",
-                        "violations=[{\"error\":\"too small\",\"field\":\"key\"}]");
+                        "violations=[{\"field\":\"key\",\"message\":\"too small\",\"error\":\"too small\"}]");
     }
 
     @Test


### PR DESCRIPTION
Two reasons:
- `javax.validation.ConstraintViolation::getMessage` exists, not `ConstraintViolation::getError`
- http://opensource.zalando.com/problem/constraint-violation/ + https://github.com/zalando/problem-spring-web/blob/main/problem-violations/src/main/java/org/zalando/problem/violations/Violation.java

`error` field stays intact for now, but deprecated.