### PR TITLE
[#56] Enable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+updates:
+  - package-ecosystem: maven
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "04:00"
+      timezone: Europe/Warsaw
+    labels:
+      - dependencies
+    allow:
+      # Quarkus
+      - dependency-name: io.quarkus:*
+      # Zalando
+      - dependency-name: org.zalando:problem
+      # Assertj
+      - dependency-name: org.assertj:assertj-core
+      # Jmh
+      - dependency-name: org.openjdk.jmh:*
+      # jsr305
+      - dependency-name: com.google.code.findbugs:jsr305
+      # Maven plugins
+      - dependency-name: org.apache.maven.plugins:*
+      - dependency-name: org.simplify4u.plugins:sign-maven-plugin
+      - dependency-name: de.thetaphi:forbiddenapis
+      - dependency-name: net.revelc.code.formatter:formatter-maven-plugin
+      - dependency-name: net.revelc.code:impsort-maven-plugin
+    rebase-strategy: disabled

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,16 +9,12 @@ updates:
     labels:
       - dependencies
     allow:
-      # Quarkus
+      # Runtime / test dependencies
       - dependency-name: io.quarkus:*
-      # Zalando
-      - dependency-name: org.zalando:problem
-      # Assertj
-      - dependency-name: org.assertj:assertj-core
-      # Jmh
-      - dependency-name: org.openjdk.jmh:*
-      # jsr305
       - dependency-name: com.google.code.findbugs:jsr305
+      - dependency-name: org.zalando:problem
+      - dependency-name: org.assertj:assertj-core
+      - dependency-name: org.openjdk.jmh:*
       # Maven plugins
       - dependency-name: org.apache.maven.plugins:*
       - dependency-name: org.simplify4u.plugins:sign-maven-plugin


### PR DESCRIPTION
**Dependabot configuration file**

Few remarks:
- Native github dependabot doesn't have automerge option so merging needs to be done manually (https://github.com/dependabot/dependabot-core/issues/1973)
- For some strange reason when dependabot checks for `quarkus-maven-plugin` inside `integration-test` module it takes current version of `quarkus.version` and tries to apply it to first occurance in profile section which causes issue with integration tests because this should stay untouched. I cannot find good solution for this so I would simply check each PR manually to prevent from such behavior.
- When you decide to merge this PR dependabot will not create new PRs beacuse it checks for all the PR in the repo history and will find closed ones. You can check the log file inside (`Insights` -> `Dependency graph` -> `Dependabot`) 
 
