### PR TITLE
Added mapper for jackson.InvalidFormatExceptionMapper

### DIFF
--- a/deployment/src/main/java/com/tietoevry/quarkus/resteasy/problem/deployment/ProblemProcessor.java
+++ b/deployment/src/main/java/com/tietoevry/quarkus/resteasy/problem/deployment/ProblemProcessor.java
@@ -42,6 +42,7 @@ public class ProblemProcessor {
         mappers.put("org.zalando.problem.ThrowableProblem", "ZalandoProblemMapper");
 
         mappers.put("com.fasterxml.jackson.core.JsonProcessingException", "jackson.JsonProcessingExceptionMapper");
+        mappers.put("com.fasterxml.jackson.databind.exc.InvalidFormatException", "jackson.InvalidFormatExceptionMapper");
         mappers.put("javax.ws.rs.ProcessingException", "jsonb.RestEasyClassicJsonbExceptionMapper");
         mappers.put("javax.json.bind.JsonbException", "jsonb.JsonbExceptionMapper");
 

--- a/integration-test/src/main/java/com/tietoevry/quarkus/resteasy/problem/JsonExceptionsResource.java
+++ b/integration-test/src/main/java/com/tietoevry/quarkus/resteasy/problem/JsonExceptionsResource.java
@@ -5,6 +5,7 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+import java.util.UUID;
 
 @Path("/throw/json/")
 @Consumes(MediaType.APPLICATION_JSON)
@@ -16,7 +17,13 @@ public class JsonExceptionsResource {
     }
 
     public static final class TestRequestBody {
-        public int key;
+        public UUID uuid_field_1;
+
+        public Nested nested;
+
+        public static final class Nested {
+            public UUID uuid_field_2;
+        }
     }
 
 }

--- a/integration-test/src/test/java/com/tietoevry/quarkus/resteasy/problem/JsonMappersIT.java
+++ b/integration-test/src/test/java/com/tietoevry/quarkus/resteasy/problem/JsonMappersIT.java
@@ -3,14 +3,34 @@ package com.tietoevry.quarkus.resteasy.problem;
 import static io.restassured.RestAssured.given;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.oneOf;
 
-import io.quarkus.test.junit.QuarkusTest;
-import io.restassured.RestAssured;
+import io.restassured.response.ValidatableResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
 @QuarkusTest
 class JsonMappersIT {
+
+    static final String JACKSON_MALFORMED_PAYLOAD_DETAIL = "Unexpected end-of-input within/between Object entries";
+    static final String JACKSON_FIELD_SERIALIZATION_ERROR_DETAIL = "Cannot deserialize value of type `java.util.UUID` from String \"ABC-DEF-GHI\": UUID has to be represented by standard 36-char representation";
+
+    static final String JSONB_CLASSIC_MALFORMED_PAYLOAD_DETAIL = "Internal error: Invalid token=EOF at (line no=1, column no=14, offset=13). Expected tokens are: [CURLYOPEN, SQUAREOPEN, STRING, NUMBER, TRUE, FALSE, NULL]";
+    static final String JSONB_REACTIVE_MALFORMED_PAYLOAD_DETAIL = "Invalid token=EOF at (line no=1, column no=14, offset=13). Expected tokens are: [CURLYOPEN, SQUAREOPEN, STRING, NUMBER, TRUE, FALSE, NULL]";
+    static final String JSONB_CLASSIC_FIELD_SERIALIZATION_ERROR_DETAIL = "Internal error: Invalid UUID string: ABC-DEF-GHI";
+    static final String JSONB_REACTIVE_FIELD_SERIALIZATION_ERROR_DETAIL = "Invalid UUID string: ABC-DEF-GHI";
+
+    private Logger logger = LoggerFactory.getLogger(JsonMappersIT.class);
 
     static {
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
@@ -35,6 +55,51 @@ class JsonMappersIT {
                 .contentType(APPLICATION_JSON)
                 .post("/throw/json")
                 .then()
+                .statusCode(BAD_REQUEST.getStatusCode())
+                .body("detail", oneOf(JACKSON_MALFORMED_PAYLOAD_DETAIL, JSONB_CLASSIC_MALFORMED_PAYLOAD_DETAIL, JSONB_REACTIVE_MALFORMED_PAYLOAD_DETAIL));
+    }
+
+    @Test
+    @DisplayName("Should return Bad Request(400) when field in payload cannot be deserialized")
+    void shouldThrowBadRequestForInvalidFieldFormat() throws IOException {
+        ValidatableResponse response = given()
+                .body("{\"uuid_field_1\":\"ABC-DEF-GHI\"}")
+                .contentType(APPLICATION_JSON)
+                .post("/throw/json")
+                .then()
                 .statusCode(BAD_REQUEST.getStatusCode());
+
+        /**
+         *  @see io.quarkus.resteasy.reactive.jackson.runtime.serialisers.JacksonMessageBodyReader, line 55
+         */
+        if(response.extract().body().asInputStream().available() == 0) {
+            logger.info("Reactive impl returns empty body, skipping further validation");
+            return;
+        }
+
+        response.body("detail", oneOf(JACKSON_FIELD_SERIALIZATION_ERROR_DETAIL, JSONB_CLASSIC_FIELD_SERIALIZATION_ERROR_DETAIL, JSONB_REACTIVE_FIELD_SERIALIZATION_ERROR_DETAIL))
+                .body("field", anyOf(is("uuid_field_1"), nullValue())); // field not available in jsonb impl
+    }
+
+    @Test
+    @DisplayName("Should return Bad Request(400) when field in payload cannot be deserialized #2")
+    void shouldThrowBadRequestForInvalidFieldFormat2() throws IOException {
+        ValidatableResponse response = given()
+                .body("{\"nested\": {\"uuid_field_2\":\"ABC-DEF-GHI\"}}")
+                .contentType(APPLICATION_JSON)
+                .post("/throw/json")
+                .then()
+                .statusCode(BAD_REQUEST.getStatusCode());
+
+        /**
+         *  @see io.quarkus.resteasy.reactive.jackson.runtime.serialisers.JacksonMessageBodyReader, line 55
+         */
+        if(response.extract().body().asInputStream().available() == 0) {
+            logger.info("Reactive impl returns empty body, skipping further validation");
+            return;
+        }
+
+        response.body("detail", oneOf(JACKSON_FIELD_SERIALIZATION_ERROR_DETAIL, JSONB_CLASSIC_FIELD_SERIALIZATION_ERROR_DETAIL, JSONB_REACTIVE_FIELD_SERIALIZATION_ERROR_DETAIL))
+                .body("field", anyOf(is("nested.uuid_field_2"), nullValue())); // field not available in jsonb impl
     }
 }

--- a/runtime/src/main/java/com/tietoevry/quarkus/resteasy/problem/jackson/InvalidFormatExceptionMapper.java
+++ b/runtime/src/main/java/com/tietoevry/quarkus/resteasy/problem/jackson/InvalidFormatExceptionMapper.java
@@ -1,0 +1,31 @@
+package com.tietoevry.quarkus.resteasy.problem.jackson;
+
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import com.tietoevry.quarkus.resteasy.problem.ExceptionMapperBase;
+import com.tietoevry.quarkus.resteasy.problem.HttpProblem;
+import java.util.stream.Collectors;
+import javax.annotation.Priority;
+import javax.ws.rs.Priorities;
+import javax.ws.rs.core.Response;
+
+/**
+ * Mapper for Jackson InvalidFormatException, which is more specialised version of JsonProcessingException
+ */
+@Priority(Priorities.USER)
+public final class InvalidFormatExceptionMapper extends ExceptionMapperBase<InvalidFormatException> {
+
+    @Override
+    protected HttpProblem toProblem(InvalidFormatException exception) {
+        String field = exception.getPath().stream()
+                .map(JsonMappingException.Reference::getFieldName)
+                .collect(Collectors.joining("."));
+
+        return HttpProblem.builder()
+                .withStatus(Response.Status.BAD_REQUEST)
+                .withTitle(Response.Status.BAD_REQUEST.getReasonPhrase())
+                .withDetail(exception.getOriginalMessage())
+                .with("field", field)
+                .build();
+    }
+}

--- a/runtime/src/main/java/com/tietoevry/quarkus/resteasy/problem/jackson/JsonProcessingExceptionMapper.java
+++ b/runtime/src/main/java/com/tietoevry/quarkus/resteasy/problem/jackson/JsonProcessingExceptionMapper.java
@@ -16,6 +16,6 @@ public final class JsonProcessingExceptionMapper extends ExceptionMapperBase<Jso
 
     @Override
     protected HttpProblem toProblem(JsonProcessingException exception) {
-        return HttpProblem.valueOf(BAD_REQUEST, exception.getMessage());
+        return HttpProblem.valueOf(BAD_REQUEST, exception.getOriginalMessage());
     }
 }

--- a/runtime/src/test/java/com/tietoevry/quarkus/resteasy/problem/jackson/InvalidFormatExceptionMapperTest.java
+++ b/runtime/src/test/java/com/tietoevry/quarkus/resteasy/problem/jackson/InvalidFormatExceptionMapperTest.java
@@ -1,0 +1,33 @@
+package com.tietoevry.quarkus.resteasy.problem.jackson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import com.tietoevry.quarkus.resteasy.problem.HttpProblem;
+import javax.ws.rs.core.Response;
+import org.junit.jupiter.api.Test;
+
+class InvalidFormatExceptionMapperTest {
+
+    InvalidFormatExceptionMapper mapper = new InvalidFormatExceptionMapper();
+
+    @Test
+    void shouldProduceHttp400WithFieldInfo() {
+        InvalidFormatException exception = new InvalidFormatException(mock(JsonParser.class),
+                "Invalid format of the field", this, this.getClass());
+        exception.prependPath(new JsonMappingException.Reference(this, "customFieldName"));
+
+        Response response = mapper.toResponse(exception);
+
+        assertThat(response.getStatus()).isEqualTo(400);
+        assertThat(response.getMediaType()).isEqualTo(HttpProblem.MEDIA_TYPE);
+        assertThat(response.getEntity())
+                .isInstanceOf(HttpProblem.class)
+                .hasFieldOrPropertyWithValue("detail", "Invalid format of the field")
+                .hasFieldOrPropertyWithValue("parameters.field", "customFieldName");
+    }
+
+}


### PR DESCRIPTION
Problem we're solving here is too many details when jackson throws InvalidFormatException, at the same time we don't know which field causes the problem:
```
{​
   "status": 400,
   "title": "Bad Request",
   "detail": "Cannot deserialize value of type `java.util.UUID` from String \"a\": UUID has to be represented by standard 36-char representation\n at [Source: (io.undertow.servlet.spec.ServletInputStreamImpl); line: 1, column: 27] (through reference chain: app.kyln.tech.common.translog.kafka.shared.producer.generic.api.v1.dto.AddDocumentCollectionRequest[\"document_collection_id\"])",
   (...)
}​
```

After merging this PR, the above example will look like this:
```
{​
   "status": 400,
   "title": "Bad Request",
   "detail": "Cannot deserialize value of type `java.util.UUID` from String \"a\": UUID has to be represented by standard 36-char representation",
   "field": "<malformed_uuid_field>"
   (...)
}​
```

BUT every resteasy implementation will look a bit different, as the errors thrown are different, and sometimes (reactive) they even bypass exception mappers :(
