### PR TITLE
[WIP] Quarkus 2.0.0 experiments

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
 
       - name: Cache local Maven repository
         uses: actions/cache@v2

--- a/.github/workflows/maven-regression.yaml
+++ b/.github/workflows/maven-regression.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [ "1.5", "1.6", "1.7", "1.8", "1.9", "1.10", "1.11", "1.12" ]
+        version: [ "1.5", "1.6", "1.7", "1.8", "1.9", "1.10", "1.11", "1.12", "1.13" ]
         json-provider: [ "jsonb-classic", "jackson-classic" ]
 
     steps:

--- a/.github/workflows/maven-regression.yaml
+++ b/.github/workflows/maven-regression.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
 
       - name: Cache local Maven repository
         uses: actions/cache@v2

--- a/.github/workflows/quickstart-tests.yaml
+++ b/.github/workflows/quickstart-tests.yaml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Generate Quickstart App
         working-directory: ./quickstart
-        run: mvn io.quarkus:quarkus-maven-plugin:1.13.2.Final:create -Dextensions="resteasy,${{ matrix.json-provider }}" -DprojectGroupId=problem -DprojectArtifactId=quarkus-resteasy-problem-playground -DclassName="problem.HelloResource" -Dpath="/hello"
+        run: mvn io.quarkus:quarkus-maven-plugin:2.0.0.Alpha1:create -Dextensions="resteasy,${{ matrix.json-provider }}" -DprojectGroupId=problem -DprojectArtifactId=quarkus-resteasy-problem-playground -DclassName="problem.HelloResource" -Dpath="/hello"
 
       - name: Add extension dependency
         working-directory: ./quickstart/quarkus-resteasy-problem-playground

--- a/.github/workflows/quickstart-tests.yaml
+++ b/.github/workflows/quickstart-tests.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
 
       - name: Cache local Maven repository
         uses: actions/cache@v2

--- a/.github/workflows/static-code-analysis.yaml
+++ b/.github/workflows/static-code-analysis.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
 
       - name: Cache local Maven repository
         uses: actions/cache@v2

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
 
       - name: Cache local Maven repository
         uses: actions/cache@v2

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@
 This extension registers few JaxRS Exceptions Mappers for common exceptions thrown by Quarkus apps, which turn exceptions into standardized HTTP responses described in RFC, with content type `application/problem+json`. See [Built-in exception mappers](#built-in-exception-mappers) section for more details.
 
 Supports:
-- _quarkus-resteasy-jackson_ and _quarkus-resteasy-jsonb_ for Quarkus 1.4.2 and newer
-- _quarkus-resteasy-reactive-jackson_ and _quarkus-resteasy-reactive-jsonb_ for Quarkus 1.11.6 and newer
+- _quarkus-resteasy-jackson_ and _quarkus-resteasy-jsonb_ for Quarkus 1.4.2 and newer (including 2.0.0.Alpha1)
+- _quarkus-resteasy-reactive-jackson_ and _quarkus-resteasy-reactive-jsonb_ for Quarkus 1.11.6 and newer (including 2.0.0.Alpha1)
 - JVM and native mode
 - Java 8+
 
@@ -35,7 +35,7 @@ You may also want to check [this article](https://dzone.com/articles/when-http-s
 ## Usage
 Create a new Quarkus project with the following command (you can also use `resteasy-jsonb` or reactive equivalents: `resteasy-reactive-jackson` / `resteasy-reactive-jsonb`):
 ```shell
-mvn io.quarkus:quarkus-maven-plugin:1.13.2.Final:create \
+mvn io.quarkus:quarkus-maven-plugin:2.0.0.Alpha1.Final:create \
     -DprojectGroupId=problem \
     -DprojectArtifactId=quarkus-resteasy-problem-playground \
     -DclassName="problem.HelloResource" \

--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -149,6 +149,13 @@
         </profile>
 
         <profile>
+            <id>quarkus-1.13</id>
+            <properties>
+                <quarkus.version>1.13.2.Final</quarkus.version>
+            </properties>
+        </profile>
+
+        <profile>
             <id>quarkus-1.12</id>
             <properties>
                 <quarkus.version>1.12.2.Final</quarkus.version>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <!-- runtime/test dependencies -->
-        <quarkus.version>1.13.2.Final</quarkus.version>
+        <quarkus.version>2.0.0.Alpha1</quarkus.version>
         <zalando-problem.version>0.25.0</zalando-problem.version>
         <assertj.version>3.19.0</assertj.version>
         <jmh.version>1.29</jmh.version>


### PR DESCRIPTION
First impression - looks very good unless we still want to target java 1.8, only some minor problems with `smallrye-metrics` not working in quarkus 1.11 and older.

The biggest problem is quarkus 2.0.0.Alpha1 compiler plugin doesn't work with JDK 1.8, so it's not possible to compile this extension targeting 1.8 without splitting artifacts fot 8 and 11. To be continued.