### PR TITLE
Quarkus 2.0 support, switched to java 11

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -14,9 +14,7 @@ jobs:
       matrix:
         maven_profiles: [
             "jackson-classic", "jsonb-classic",
-            "jackson-reactive", "jsonb-reactive",
-            "jackson-classic,quarkus-1.4", "jsonb-classic,quarkus-1.4",
-            "jackson-reactive,quarkus-1.11", "jsonb-reactive,quarkus-1.11"
+            "jackson-reactive", "jsonb-reactive"
         ]
 
     steps:
@@ -25,7 +23,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
 
       - name: Cache local Maven repository
         uses: actions/cache@v2

--- a/.github/workflows/maven-regression.yaml
+++ b/.github/workflows/maven-regression.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [ "1.5", "1.6", "1.7", "1.8", "1.9", "1.10", "1.11", "1.12" ]
+        version: [ "2.0" ]
         json-provider: [ "jsonb-classic", "jackson-classic" ]
 
     steps:
@@ -20,7 +20,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
 
       - name: Cache local Maven repository
         uses: actions/cache@v2

--- a/.github/workflows/native-mode-tests.yaml
+++ b/.github/workflows/native-mode-tests.yaml
@@ -35,7 +35,7 @@ jobs:
 
       - uses: DeLaGuardo/setup-graalvm@master
         with:
-          graalvm: '21.0.0.2'
+          graalvm: '21.1.0'
           java: 'java11'
 
       - name: Native Tests

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
 
       - name: Cache local Maven repository
         uses: actions/cache@v2

--- a/.github/workflows/quickstart-tests.yaml
+++ b/.github/workflows/quickstart-tests.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
 
       - name: Cache local Maven repository
         uses: actions/cache@v2

--- a/.github/workflows/static-code-analysis.yaml
+++ b/.github/workflows/static-code-analysis.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
 
       - name: Cache local Maven repository
         uses: actions/cache@v2

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
 
       - name: Cache local Maven repository
         uses: actions/cache@v2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,8 +4,8 @@ You're more than welcome to work on this extension. Check [issues](../../issues/
 or add your own suggestions and start discussion. Then create fork or branch and Pull Request once it's ready.
 
 ## Setup
-- JDK 8
-- GraalVM + JDK 11 for native test run, check [Quarkus Contributing guide](https://github.com/quarkusio/quarkus/blob/main/CONTRIBUTING.md#setup) for more details.
+- JDK 11
+- GraalVM for native test run, check [Quarkus Contributing guide](https://github.com/quarkusio/quarkus/blob/main/CONTRIBUTING.md#setup) for more details.
 
 ### IDE Config and Code Style
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![Release](https://img.shields.io/maven-central/v/com.tietoevry.quarkus/quarkus-resteasy-problem)](https://search.maven.org/artifact/com.tietoevry.quarkus/quarkus-resteasy-problem)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://github.com/TietoEVRY/quarkus-resteasy-problem/blob/master/LICENSE.txt)
-![JVM](https://img.shields.io/badge/JVM-1.8+-green.svg)
 ![Quarkus](https://img.shields.io/badge/Quarkus-1.4.2%20+-green.svg)
+![Quarkus](https://img.shields.io/badge/Quarkus-2.0.0.CR3-red.svg)
 
 [![Build status](https://github.com/TietoEVRY/quarkus-resteasy-problem/actions/workflows/unit-tests.yaml/badge.svg)](https://github.com/TietoEVRY/quarkus-resteasy-problem/actions)
 [![Build status](https://github.com/TietoEVRY/quarkus-resteasy-problem/actions/workflows/integration-tests.yaml/badge.svg)](https://github.com/TietoEVRY/quarkus-resteasy-problem/actions)
@@ -15,7 +15,8 @@ This extension supports:
 - _quarkus-resteasy-jackson_ and _quarkus-resteasy-jsonb_ for Quarkus 1.4.2 and newer
 - _quarkus-resteasy-reactive-jackson_ and _quarkus-resteasy-reactive-jsonb_ for Quarkus 1.11.6 and newer
 - JVM and native mode
-- Java 8+
+- Quarkus v2.X / Java 11+ with and quarkus-resteasy-problem v2.X
+- Quarkus v1.X / Java 8+ with and quarkus-resteasy-problem v1.X
 
 ## Why you should use this extension?
 - __consistency__ - it unifies your REST API error messages, and gives it much needed consistency, no matter which JSON provider (Jackson vs JsonB) or paradigm (classic/blocking vs reactive) you're using.   
@@ -38,9 +39,9 @@ so-called "HTTP APIs" are usually not.
 ```
 
 ## Usage
-### New Quarkus project
+### Quarkus 1.X / Java 1.8+
 Create a new Quarkus project with the following command:
-```shell
+```shell 
 mvn io.quarkus:quarkus-maven-plugin:1.13.7.Final:create \
     -DprojectGroupId=problem \
     -DprojectArtifactId=quarkus-resteasy-problem-playground \
@@ -49,9 +50,7 @@ mvn io.quarkus:quarkus-maven-plugin:1.13.7.Final:create \
     -Dextensions="resteasy,resteasy-jackson,com.tietoevry.quarkus:quarkus-resteasy-problem:1.0.0"
 cd quarkus-resteasy-problem-playground
 ```
-**Hint:** you can also use `resteasy-jsonb` or reactive equivalents: `resteasy-reactive-jackson` / `resteasy-reactive-jsonb` instead of `resteasy-jackson`
-
-Existing Quarkus project: add the following dependency to `pom.xml`:
+Or add the following dependency to `pom.xml` in existing project:
 ```xml
 <dependency>
     <groupId>com.tietoevry.quarkus</groupId>
@@ -59,6 +58,28 @@ Existing Quarkus project: add the following dependency to `pom.xml`:
     <version>1.0.0</version>
 </dependency>
 ```
+
+### Quarkus 2.X / Java 11+
+```shell
+mvn io.quarkus:quarkus-maven-plugin:2.0.0.CR3:create \
+    -DprojectGroupId=problem \
+    -DprojectArtifactId=quarkus-resteasy-problem-playground \
+    -DclassName="problem.HelloResource" \
+    -Dpath="/hello" \
+    -Dextensions="resteasy,resteasy-jackson,com.tietoevry.quarkus:quarkus-resteasy-problem:2.0.0.CR3"
+cd quarkus-resteasy-problem-playground
+```
+or:
+```xml
+<dependency>
+    <groupId>com.tietoevry.quarkus</groupId>
+    <artifactId>quarkus-resteasy-problem</artifactId>
+    <version>2.0.0.CR3</version>
+</dependency>
+```
+
+**Hint:** you can also use `resteasy-jsonb` or reactive equivalents: `resteasy-reactive-jackson` / `resteasy-reactive-jsonb` instead of `resteasy-jackson`
+
 
 Once you run Quarkus: `./mvnw compile quarkus:dev`, and you will find `resteasy-problem` in the logs:
 <pre>

--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.tietoevry.quarkus</groupId>
         <artifactId>quarkus-resteasy-problem-parent</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>quarkus-resteasy-problem-deployment</artifactId>

--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.tietoevry.quarkus</groupId>
         <artifactId>quarkus-resteasy-problem-parent</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>quarkus-resteasy-problem-integration-test</artifactId>
@@ -146,69 +146,6 @@
                     <artifactId>quarkus-resteasy-reactive-jsonb</artifactId>
                 </dependency>
             </dependencies>
-        </profile>
-
-        <profile>
-            <id>quarkus-1.12</id>
-            <properties>
-                <quarkus.version>1.12.2.Final</quarkus.version>
-            </properties>
-        </profile>
-
-        <profile>
-            <id>quarkus-1.11</id>
-            <properties>
-                <quarkus.version>1.11.6.Final</quarkus.version>
-            </properties>
-        </profile>
-
-        <profile>
-            <id>quarkus-1.10</id>
-            <properties>
-                <quarkus.version>1.10.5.Final</quarkus.version>
-            </properties>
-        </profile>
-
-        <profile>
-            <id>quarkus-1.9</id>
-            <properties>
-                <quarkus.version>1.9.2.Final</quarkus.version>
-            </properties>
-        </profile>
-
-        <profile>
-            <id>quarkus-1.8</id>
-            <properties>
-                <quarkus.version>1.8.3.Final</quarkus.version>
-            </properties>
-        </profile>
-
-        <profile>
-            <id>quarkus-1.7</id>
-            <properties>
-                <quarkus.version>1.7.5.Final</quarkus.version>
-            </properties>
-        </profile>
-
-        <profile>
-            <id>quarkus-1.6</id>
-            <properties>
-                <quarkus.version>1.6.1.Final</quarkus.version>
-            </properties>
-        </profile>
-
-        <profile>
-            <id>quarkus-1.5</id>
-            <properties>
-                <quarkus.version>1.5.2.Final</quarkus.version>
-            </properties>
-        </profile>
-
-        <profile>
-            <id>quarkus-1.4</id>
-            <properties>
-                <quarkus.version>1.4.2.Final</quarkus.version>
-            </properties>
         </profile>
 
         <profile>

--- a/integration-test/src/test/java/com/tietoevry/quarkus/resteasy/problem/MetricsIT.java
+++ b/integration-test/src/test/java/com/tietoevry/quarkus/resteasy/problem/MetricsIT.java
@@ -34,7 +34,7 @@ class MetricsIT {
         ExtractableResponse response = given()
                 .accept(ContentType.JSON)
                 .when()
-                .get("/metrics/application/http.error")
+                .get("/q/metrics/application/http.error")
                 .then()
                 .extract();
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.tietoevry.quarkus</groupId>
     <artifactId>quarkus-resteasy-problem-parent</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Quarkus - RESTeasy - Problem - Parent</name>
@@ -13,13 +13,13 @@
     <url>https://github.com/TietoEVRY/quarkus-resteasy-problem</url>
 
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <!-- runtime/test dependencies -->
-        <quarkus.version>1.13.7.Final</quarkus.version>
+        <quarkus.version>2.0.0.CR3</quarkus.version>
         <zalando-problem.version>0.26.0</zalando-problem.version>
         <assertj.version>3.20.1</assertj.version>
         <jmh.version>1.32</jmh.version>

--- a/run-jvm-tests
+++ b/run-jvm-tests
@@ -2,14 +2,14 @@
 
 java_ver=$(java -version 2>&1 | head -1 | cut -d'"' -f2 | sed '/^1\./s///' | cut -d'.' -f1)
 
-if [[ "$java_ver" != "8" ]]; then
-  read -p "Expected Java version is 1.8, while $java_ver was found. Switch to java 1.8 (y/n)? " choice
+if [[ "$java_ver" != "11" ]]; then
+  read -p "Expected Java version is 11, while $java_ver was found. Switch to java 11 (y/n)? " choice
   if [[ "$choice" != "y" ]]; then
     exit;
   fi
 
-  echo "Switching Java to 1.8"
-  export JAVA_HOME=$(/usr/libexec/java_home -v 1.8);
+  echo "Switching java version to 11"
+  export JAVA_HOME=$(/usr/libexec/java_home -v 11);
 fi
 
 set -x
@@ -21,8 +21,3 @@ set -e
 ./mvnw clean verify -Pjsonb-classic -pl integration-test
 ./mvnw clean verify -Pjackson-reactive -pl integration-test
 ./mvnw clean verify -Pjsonb-reactive -pl integration-test
-
-./mvnw clean verify -Pjackson-classic,quarkus-1.4 -pl integration-test
-./mvnw clean verify -Pjsonb-classic,quarkus-1.4 -pl integration-test
-./mvnw clean verify -Pjackson-reactive,quarkus-1.11 -pl integration-test
-./mvnw clean verify -Pjsonb-reactive,quarkus-1.11 -pl integration-test

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.tietoevry.quarkus</groupId>
         <artifactId>quarkus-resteasy-problem-parent</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>quarkus-resteasy-problem</artifactId>


### PR DESCRIPTION
### Notes from round 1 (#100)
_First impression - looks very good unless we still want to target java 1.8, only some minor problems with smallrye-metrics not working in quarkus 1.11 and older._

_The biggest problem is quarkus 2.0.0.Alpha1 compiler plugin doesn't work with JDK 1.8, so it's not possible to compile this extension targeting 1.8 without splitting artifacts fot 8 and 11. To be continued._

### Round 2 (this PR)
It seems that we will have to maintain 2 extension versions: one for jvm 1.8, and another for 11+, and backport features/fixes to 1.8 branch for some time at least. One possible strategy is to release v1.0 and keep it in jvm1.8 branch, and release v.2.0 and keep it in master (build for jvm 11 only).