### PR TITLE
Fix for: Fails with Quarkus 2.12.0 due to ProblemProcessor#warnOnMissingSmallryeMetricsDependency

### DIFF
--- a/.github/workflows/latest-stable-compatibility-tests.yaml
+++ b/.github/workflows/latest-stable-compatibility-tests.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         json-provider: [ "jackson-classic", "jsonb-classic", "jackson-reactive", "jsonb-reactive" ]
-        quarkus-version: [ "2.0", "2.1", "2.2", "2.3", "2.4", "2.5", "2.6", "2.7", "2.8", "2.9", "2.10"]
+        quarkus-version: [ "2.0", "2.1", "2.2", "2.3", "2.4", "2.5", "2.6", "2.7", "2.8", "2.9", "2.10", "2.11"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/maven-regression.yaml
+++ b/.github/workflows/maven-regression.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        quarkus-version: [ "2.0", "2.1", "2.2", "2.3", "2.4", "2.5", "2.6", "2.7", "2.8", "2.9", "2.10"]
+        quarkus-version: [ "2.0", "2.1", "2.2", "2.3", "2.4", "2.5", "2.6", "2.7", "2.8", "2.9", "2.10", "2.11"]
         json-provider: [ "jsonb-classic", "jackson-classic" ]
 
     steps:

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ so-called "HTTP APIs" are usually not.
 ### Quarkus 2.X / Java 11+
 Make sure JDK 11 is in your PATH, the run:
 ```shell
-mvn io.quarkus:quarkus-maven-plugin:2.11.2.Final:create \
+mvn io.quarkus:quarkus-maven-plugin:2.12.0.Final:create \
     -DprojectGroupId=problem \
     -DprojectArtifactId=quarkus-resteasy-problem-playground \
     -DclassName="problem.HelloResource" \

--- a/deployment/src/main/java/com/tietoevry/quarkus/resteasy/problem/deployment/ProblemProcessor.java
+++ b/deployment/src/main/java/com/tietoevry/quarkus/resteasy/problem/deployment/ProblemProcessor.java
@@ -153,14 +153,6 @@ public class ProblemProcessor {
         }
     }
 
-    @BuildStep(onlyIfNot = QuarkusSmallryeMetricsDetector.class)
-    void warnOnMissingSmallryeMetricsDependency(ProblemBuildConfig config) {
-        if (config.metricsEnabled) {
-            logger().warn("quarkus.resteasy.problem.metrics.enabled is set to true, but quarkus-smallrye-metrics not "
-                    + "found in the classpath");
-        }
-    }
-
     protected Logger logger() {
         return LoggerFactory.getLogger(FEATURE_NAME);
     }

--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -228,6 +228,13 @@
                 <quarkus.version>2.10.3.Final</quarkus.version>
             </properties>
         </profile>
+        
+        <profile>
+            <id>quarkus-2.11</id>
+            <properties>
+                <quarkus.version>2.11.2.Final</quarkus.version>
+            </properties>
+        </profile>
 
         <profile>
             <id>native</id>

--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -232,7 +232,7 @@
         <profile>
             <id>quarkus-2.11</id>
             <properties>
-                <quarkus.version>2.11.2.Final</quarkus.version>
+                <quarkus.version>2.11.3.Final</quarkus.version>
             </properties>
         </profile>
 

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <!-- runtime/test dependencies -->
-        <quarkus.version>2.12.0.CR1</quarkus.version>
+        <quarkus.version>2.12.0.Final</quarkus.version>
         <zalando-problem.version>0.27.1</zalando-problem.version>
         <assertj.version>3.23.1</assertj.version>
         <jmh.version>1.35</jmh.version>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <!-- runtime/test dependencies -->
-        <quarkus.version>2.11.2.Final</quarkus.version>
+        <quarkus.version>2.12.0.CR1</quarkus.version>
         <zalando-problem.version>0.27.1</zalando-problem.version>
         <assertj.version>3.23.1</assertj.version>
         <jmh.version>1.35</jmh.version>


### PR DESCRIPTION
The only sensible option I see to keep one codebase/binary version that will still work in both Quarkus 2.0.X and 2.12.X is to remove this 'convenience' warning message completely.

Closes #223