### PR TITLE
Return HTTP 500 instead of 400 on ValidationException (#254)

### DIFF
--- a/integration-test/src/main/java/com/tietoevry/quarkus/resteasy/problem/ValidationExceptionsResource.java
+++ b/integration-test/src/main/java/com/tietoevry/quarkus/resteasy/problem/ValidationExceptionsResource.java
@@ -2,6 +2,7 @@ package com.tietoevry.quarkus.resteasy.problem;
 
 import javax.validation.Valid;
 import javax.validation.ValidationException;
+import javax.validation.constraints.AssertFalse;
 import javax.validation.constraints.Min;
 import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;
@@ -15,12 +16,17 @@ import org.hibernate.validator.constraints.Length;
 
 @Path("/throw/validation/")
 @Produces(MediaType.APPLICATION_JSON)
-public class ValdationExceptionsResource {
+public class ValidationExceptionsResource {
 
     @GET
     @Path("/violation-exception")
     public void throwViolationException(@QueryParam("message") String message) {
         throw new ValidationException(message);
+    }
+
+    @GET
+    @Path("/constraint-declaration-exception")
+    public void throwConstraintDeclarationException(@AssertFalse @QueryParam("message") String message) {
     }
 
     @POST

--- a/integration-test/src/test/java/com/tietoevry/quarkus/resteasy/problem/ValidationMappersIT.java
+++ b/integration-test/src/test/java/com/tietoevry/quarkus/resteasy/problem/ValidationMappersIT.java
@@ -3,6 +3,7 @@ package com.tietoevry.quarkus.resteasy.problem;
 import static io.restassured.RestAssured.given;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.nullValue;
@@ -21,15 +22,28 @@ class ValidationMappersIT {
     }
 
     @Test
-    void violationShouldReturnDetails() {
+    void violationShouldReturn500() {
         given()
                 .queryParam("message", SAMPLE_DETAIL)
                 .get("/throw/validation/violation-exception")
                 .then()
-                .statusCode(BAD_REQUEST.getStatusCode())
-                .body("title", equalTo(BAD_REQUEST.getReasonPhrase()))
-                .body("status", equalTo(BAD_REQUEST.getStatusCode()))
-                .body("detail", equalTo(SAMPLE_DETAIL))
+                .statusCode(INTERNAL_SERVER_ERROR.getStatusCode())
+                .body("title", equalTo(INTERNAL_SERVER_ERROR.getReasonPhrase()))
+                .body("status", equalTo(INTERNAL_SERVER_ERROR.getStatusCode()))
+                .body("detail", nullValue())
+                .body("stacktrace", nullValue());
+    }
+
+    @Test
+    void constraintDeclarationExceptionShouldReturn500() {
+        given()
+                .queryParam("message", SAMPLE_DETAIL)
+                .get("/throw/validation/constraint-declaration-exception")
+                .then()
+                .statusCode(INTERNAL_SERVER_ERROR.getStatusCode())
+                .body("title", equalTo(INTERNAL_SERVER_ERROR.getReasonPhrase()))
+                .body("status", equalTo(INTERNAL_SERVER_ERROR.getStatusCode()))
+                .body("detail", nullValue())
                 .body("stacktrace", nullValue());
     }
 

--- a/runtime/src/main/java/com/tietoevry/quarkus/resteasy/problem/validation/ValidationExceptionMapper.java
+++ b/runtime/src/main/java/com/tietoevry/quarkus/resteasy/problem/validation/ValidationExceptionMapper.java
@@ -1,6 +1,6 @@
 package com.tietoevry.quarkus.resteasy.problem.validation;
 
-import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
 
 import com.tietoevry.quarkus.resteasy.problem.ExceptionMapperBase;
 import com.tietoevry.quarkus.resteasy.problem.HttpProblem;
@@ -9,13 +9,15 @@ import javax.validation.ValidationException;
 import javax.ws.rs.Priorities;
 
 /**
- * More generic Exception Mapper compared to ConstraintViolationException - does not provide any details except the message.
+ * Exception Mapper for generic ValidationException from Bean Validation API.
+ * Unlike ConstraintViolationException these are not thrown if the input fails validation,
+ * but are instead thrown on invalid use of the API.
  */
 @Priority(Priorities.USER)
 public final class ValidationExceptionMapper extends ExceptionMapperBase<ValidationException> {
 
     @Override
     protected HttpProblem toProblem(ValidationException exception) {
-        return HttpProblem.valueOf(BAD_REQUEST, exception.getMessage());
+        return HttpProblem.valueOf(INTERNAL_SERVER_ERROR);
     }
 }


### PR DESCRIPTION
Fixes #254 by having `ValidationExceptionMapper` return a HttpProblem with `INTERNAL_SERVER_ERROR` instead of `BAD_REQUEST`.

I tried deleting the `ValidationExceptionMapper` in the hope that the exception would then be handled by the `DefaultExceptionMapper`, but that didn't work as it was instead handled by the exception mapper from Quarkus.

Also adds an additional integration-test, checking that a HTTP 500 is returned if a subclass of `ValidationException` is thrown, and renames `ValidationExceptionsResource` to fix a typo.

The branch passes both `run-jvm-tests` and `run-native-tests`, but fails when running `./mvnw verify` with an exception:
```
java.lang.IllegalStateException: The current thread cannot be blocked: vert.x-eventloop-thread-0
```
However, as the `master` branch fails with the same exception on my machine, I assume it's unrelated to the changes made in this branch.