### PR TITLE
Make `ProblemContext` fields public

### DIFF
--- a/runtime/src/main/java/com/tietoevry/quarkus/resteasy/problem/postprocessing/PostProcessorsRegistry.java
+++ b/runtime/src/main/java/com/tietoevry/quarkus/resteasy/problem/postprocessing/PostProcessorsRegistry.java
@@ -20,13 +20,13 @@ public final class PostProcessorsRegistry {
      * Removes all registered post-processors and registers default ones. Used mainly for Quarkus dev mode (live-reload) tests
      * where there's a need to reset registered processors because of config change.
      */
-    synchronized public void reset() {
+    public synchronized void reset() {
         processors.clear();
         register(new ProblemLogger(LoggerFactory.getLogger("http-problem")));
         register(new ProblemDefaultsProvider());
     }
 
-    synchronized public void register(ProblemPostProcessor processor) {
+    public synchronized void register(ProblemPostProcessor processor) {
         processors.add(processor);
         processors.sort(ProblemPostProcessor.DEFAULT_ORDERING);
     }

--- a/runtime/src/main/java/com/tietoevry/quarkus/resteasy/problem/postprocessing/ProblemContext.java
+++ b/runtime/src/main/java/com/tietoevry/quarkus/resteasy/problem/postprocessing/ProblemContext.java
@@ -25,6 +25,14 @@ public final class ProblemContext {
         this.path = path;
     }
 
+    public Throwable getCause() {
+        return cause;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
     public static ProblemContext of(Throwable exception, UriInfo uriInfo) {
         try {
             return new ProblemContext(exception, (uriInfo == null) ? null : uriInfo.getPath());

--- a/runtime/src/main/java/com/tietoevry/quarkus/resteasy/problem/postprocessing/ProblemContext.java
+++ b/runtime/src/main/java/com/tietoevry/quarkus/resteasy/problem/postprocessing/ProblemContext.java
@@ -13,24 +13,16 @@ public final class ProblemContext {
     /**
      * * Original exception caught by ExceptionMapper.
      */
-    final Throwable cause;
+    public final Throwable cause;
 
     /**
      * URI path of current endpoint.
      */
-    final String path;
+    public final String path;
 
     private ProblemContext(Throwable cause, String path) {
         this.cause = cause;
         this.path = path;
-    }
-
-    public Throwable getCause() {
-        return cause;
-    }
-
-    public String getPath() {
-        return path;
     }
 
     public static ProblemContext of(Throwable exception, UriInfo uriInfo) {


### PR DESCRIPTION
This PR fixes https://github.com/TietoEVRY/quarkus-resteasy-problem/issues/301. Without public access to ``ProblemContext`` data it's almost useless to implement custom `ProblemPostProcessor`s. In addition, this PR did some reordering of ``modifiers`` as at a first glance it looked like the ``register`` and ``rest`` methods of ``PostProcessorsRegistry`` would also not be ``public``.