### PR TITLE
Improve developer experience and documentation of registering custom `ProblemPostProcessor`

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ Example:
 ```java
 @ApplicationScoped
 @Startup // makes sure bean is instantiated eagerly on startup
-class AppCustomPostProcessor implements ProblemPostProcessor {
+class CustomPostProcessor implements ProblemPostProcessor {
     
     @Inject
     Validator validator;

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Make sure JDK 11 is in your PATH, then run:
 ```shell
 mvn io.quarkus:quarkus-maven-plugin:3.5.0:create \
     -DprojectGroupId=problem \
-    -DprojectArtifactId=quarkus-resteasy-problem-playground2 \
+    -DprojectArtifactId=quarkus-resteasy-problem-playground \
     -DclassName="problem.HelloResource" \
     -Dpath="/hello" \
     -Dextensions="resteasy,resteasy-jackson"
@@ -217,6 +217,30 @@ application_http_error_total{status="500"} 5.0
 quarkus.log.category.http-problem.level=INFO # default: all problems are logged
 quarkus.log.category.http-problem.level=ERROR # only HTTP 5XX problems are logged
 quarkus.log.category.http-problem.level=OFF # disables all problems-related logging
+```
+
+## Custom ProblemPostProcessor
+If you want to intercept, change or augment a mapped `HttpProblem` before it gets serialized into raw HTTP response 
+body, you can create a bean extending `ProblemPostProcessor`, and override `apply` method. It will be a normal CDI bean, 
+where e.g. you can inject other beans.
+
+Example:
+```java
+@ApplicationScoped
+@Startup // makes sure bean is instantiated eagerly on startup
+class AppCustomPostProcessor implements ProblemPostProcessor {
+    
+    @Inject
+    Validator validator;
+    
+    @Override
+    public HttpProblem apply(HttpProblem httpProblem, ProblemContext problemContext) {
+        return HttpProblem.builder(httpProblem)
+                .with("injected_from_custom_post_processor", "hello world " + problemContext.path)
+                .build();
+    }
+    
+}
 ```
 
 ## Troubles?

--- a/README.md
+++ b/README.md
@@ -223,6 +223,9 @@ quarkus.log.category.http-problem.level=OFF # disables all problems-related logg
 If you want to intercept, change or augment a mapped `HttpProblem` before it gets serialized into raw HTTP response 
 body, you can create a bean extending `ProblemPostProcessor`, and override `apply` method.
 
+**Important: Make sure your implementation is thread-safe, as it may potentially be called concurrently if multiple 
+requests throw exceptions at the same time.**
+
 Example:
 ```java
 @ApplicationScoped

--- a/README.md
+++ b/README.md
@@ -221,8 +221,7 @@ quarkus.log.category.http-problem.level=OFF # disables all problems-related logg
 
 ## Custom ProblemPostProcessor
 If you want to intercept, change or augment a mapped `HttpProblem` before it gets serialized into raw HTTP response 
-body, you can create a bean extending `ProblemPostProcessor`, and override `apply` method. It will be a normal CDI bean, 
-where e.g. you can inject other beans.
+body, you can create a bean extending `ProblemPostProcessor`, and override `apply` method.
 
 Example:
 ```java
@@ -230,7 +229,7 @@ Example:
 @Startup // makes sure bean is instantiated eagerly on startup
 class CustomPostProcessor implements ProblemPostProcessor {
     
-    @Inject
+    @Inject // acts like normal bean, DI works fine etc
     Validator validator;
     
     @Override

--- a/README.md
+++ b/README.md
@@ -234,9 +234,9 @@ class AppCustomPostProcessor implements ProblemPostProcessor {
     Validator validator;
     
     @Override
-    public HttpProblem apply(HttpProblem httpProblem, ProblemContext problemContext) {
-        return HttpProblem.builder(httpProblem)
-                .with("injected_from_custom_post_processor", "hello world " + problemContext.path)
+    public HttpProblem apply(HttpProblem problem, ProblemContext context) {
+        return HttpProblem.builder(problem)
+                .with("injected_from_custom_post_processor", "hello world " + context.path)
                 .build();
     }
     

--- a/deployment/src/main/java/com/tietoevry/quarkus/resteasy/problem/deployment/ProblemProcessor.java
+++ b/deployment/src/main/java/com/tietoevry/quarkus/resteasy/problem/deployment/ProblemProcessor.java
@@ -162,6 +162,12 @@ public class ProblemProcessor {
         }
     }
 
+    @Record(RUNTIME_INIT)
+    @BuildStep
+    void registerCustomPostProcessors(ProblemRecorder recorder) {
+        recorder.registerCustomPostProcessors();
+    }
+
     protected Logger logger() {
         return LoggerFactory.getLogger(FEATURE_NAME);
     }

--- a/integration-test/src/main/java/com/tietoevry/quarkus/resteasy/problem/AppCustomPostProcessor.java
+++ b/integration-test/src/main/java/com/tietoevry/quarkus/resteasy/problem/AppCustomPostProcessor.java
@@ -15,9 +15,9 @@ class AppCustomPostProcessor implements ProblemPostProcessor {
     Validator validator;
 
     @Override
-    public HttpProblem apply(HttpProblem httpProblem, ProblemContext problemContext) {
-        return HttpProblem.builder(httpProblem)
-                .with("injected_from_custom_post_processor", "you called " + problemContext.path)
+    public HttpProblem apply(HttpProblem problem, ProblemContext context) {
+        return HttpProblem.builder(problem)
+                .with("injected_from_custom_post_processor", "you called " + context.path)
                 .build();
     }
 }

--- a/integration-test/src/main/java/com/tietoevry/quarkus/resteasy/problem/AppCustomPostProcessor.java
+++ b/integration-test/src/main/java/com/tietoevry/quarkus/resteasy/problem/AppCustomPostProcessor.java
@@ -1,0 +1,23 @@
+package com.tietoevry.quarkus.resteasy.problem;
+
+import com.tietoevry.quarkus.resteasy.problem.postprocessing.ProblemContext;
+import com.tietoevry.quarkus.resteasy.problem.postprocessing.ProblemPostProcessor;
+import io.quarkus.runtime.Startup;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.validation.Validator;
+
+@ApplicationScoped
+@Startup
+class AppCustomPostProcessor implements ProblemPostProcessor {
+
+    @Inject
+    Validator validator;
+
+    @Override
+    public HttpProblem apply(HttpProblem httpProblem, ProblemContext problemContext) {
+        return HttpProblem.builder(httpProblem)
+                .with("injected_from_custom_post_processor", "you called " + problemContext.path)
+                .build();
+    }
+}

--- a/integration-test/src/main/java/com/tietoevry/quarkus/resteasy/problem/CustomPostProcessor.java
+++ b/integration-test/src/main/java/com/tietoevry/quarkus/resteasy/problem/CustomPostProcessor.java
@@ -9,7 +9,7 @@ import jakarta.validation.Validator;
 
 @ApplicationScoped
 @Startup
-class AppCustomPostProcessor implements ProblemPostProcessor {
+class CustomPostProcessor implements ProblemPostProcessor {
 
     @Inject
     Validator validator;

--- a/integration-test/src/test/java/com/tietoevry/quarkus/resteasy/problem/GenericMappersIT.java
+++ b/integration-test/src/test/java/com/tietoevry/quarkus/resteasy/problem/GenericMappersIT.java
@@ -52,6 +52,6 @@ class GenericMappersIT {
                 .queryParam("message", SAMPLE_DETAIL)
                 .get("/throw/generic/runtime-exception")
                 .then()
-                .body("injected_from_custom_post_processor", equalTo("hello world"));
+                .body("injected_from_custom_post_processor", equalTo("you called /throw/generic/runtime-exception"));
     }
 }

--- a/integration-test/src/test/java/com/tietoevry/quarkus/resteasy/problem/GenericMappersIT.java
+++ b/integration-test/src/test/java/com/tietoevry/quarkus/resteasy/problem/GenericMappersIT.java
@@ -46,4 +46,12 @@ class GenericMappersIT {
                 .body("stacktrace", nullValue());
     }
 
+    @Test
+    void shouldRegisterProblemPostProcessorCustomImplementationsFromCDI() {
+        given()
+                .queryParam("message", SAMPLE_DETAIL)
+                .get("/throw/generic/runtime-exception")
+                .then()
+                .body("injected_from_custom_post_processor", equalTo("hello world"));
+    }
 }

--- a/runtime/src/main/java/com/tietoevry/quarkus/resteasy/problem/HttpProblem.java
+++ b/runtime/src/main/java/com/tietoevry/quarkus/resteasy/problem/HttpProblem.java
@@ -182,6 +182,7 @@ public class HttpProblem extends RuntimeException {
         }
 
         /**
+         * Adds custom property to the response.
          * @throws IllegalArgumentException if key is any of type, title, status, detail or instance
          */
         public Builder with(String key, Object value) throws IllegalArgumentException {

--- a/runtime/src/main/java/com/tietoevry/quarkus/resteasy/problem/HttpProblem.java
+++ b/runtime/src/main/java/com/tietoevry/quarkus/resteasy/problem/HttpProblem.java
@@ -183,6 +183,7 @@ public class HttpProblem extends RuntimeException {
 
         /**
          * Adds custom property to the response.
+         *
          * @throws IllegalArgumentException if key is any of type, title, status, detail or instance
          */
         public Builder with(String key, Object value) throws IllegalArgumentException {

--- a/runtime/src/main/java/com/tietoevry/quarkus/resteasy/problem/postprocessing/ProblemContext.java
+++ b/runtime/src/main/java/com/tietoevry/quarkus/resteasy/problem/postprocessing/ProblemContext.java
@@ -16,7 +16,7 @@ public final class ProblemContext {
     public final Throwable cause;
 
     /**
-     * URI path of current endpoint.
+     * URI path of the endpoint.
      */
     public final String path;
 

--- a/runtime/src/main/java/com/tietoevry/quarkus/resteasy/problem/postprocessing/ProblemPostProcessor.java
+++ b/runtime/src/main/java/com/tietoevry/quarkus/resteasy/problem/postprocessing/ProblemPostProcessor.java
@@ -15,7 +15,7 @@ public interface ProblemPostProcessor {
      * Interceptor method for HttpProblems. In case problem should be changed or enhanced, one can use
      * 'HttpProblem.builder(httpProblem)'.
      * <p>
-     * Should be thread-safe.
+     * Implementations should be thread-safe.
      *
      * @param problem Original HttpProblem, possibly processed by other processors with higher priority.
      * @param context Additional, internal metadata not included in HttpProblem

--- a/runtime/src/main/java/com/tietoevry/quarkus/resteasy/problem/postprocessing/ProblemPostProcessor.java
+++ b/runtime/src/main/java/com/tietoevry/quarkus/resteasy/problem/postprocessing/ProblemPostProcessor.java
@@ -14,11 +14,11 @@ public interface ProblemPostProcessor {
 
     /**
      * Interceptor method for HttpProblems. In case problem should be changed or enhanced, one can use 'HttpProblem.builder(httpProblem)'.
-     * @param httpProblem Original HttpProblem, possibly processed by other processors with higher priority.
-     * @param problemContext Additional, internal metadata not included in HttpProblem
+     * @param problem Original HttpProblem, possibly processed by other processors with higher priority.
+     * @param context Additional, internal metadata not included in HttpProblem
      * @return Can be original HttpProblem (for peek-type processors), changed copy or completely new HttpProblem (for map-type processors.
      */
-    HttpProblem apply(HttpProblem httpProblem, ProblemContext problemContext);
+    HttpProblem apply(HttpProblem problem, ProblemContext context);
 
     /**
      * Defines order in which processors are triggered. Bigger value means precedence before processors

--- a/runtime/src/main/java/com/tietoevry/quarkus/resteasy/problem/postprocessing/ProblemPostProcessor.java
+++ b/runtime/src/main/java/com/tietoevry/quarkus/resteasy/problem/postprocessing/ProblemPostProcessor.java
@@ -5,16 +5,25 @@ import java.util.Comparator;
 import java.util.function.BiFunction;
 
 /**
- * Post-processors use, change or enhance Problems created by ExceptionMappers via 'apply' method, before they get passed on to
- * serializers.
+ * Post-processors use, change or enhance HttpProblem created by ExceptionMappers via 'apply' method, before they get
+ * passed on to serializers.
  */
-public interface ProblemPostProcessor extends BiFunction<HttpProblem, ProblemContext, HttpProblem> {
+public interface ProblemPostProcessor {
 
     Comparator<ProblemPostProcessor> DEFAULT_ORDERING = Comparator.comparingInt(ProblemPostProcessor::priority).reversed();
 
     /**
+     * Interceptor method for HttpProblems. In case problem should be changed or enhanced, one can use 'HttpProblem.builder(httpProblem)'.
+     * @param httpProblem Original HttpProblem, possibly processed by other processors with higher priority.
+     * @param problemContext Additional, internal metadata not included in HttpProblem
+     * @return Can be original HttpProblem (for peek-type processors), changed copy or completely new HttpProblem (for map-type processors.
+     */
+    HttpProblem apply(HttpProblem httpProblem, ProblemContext problemContext);
+
+    /**
      * Defines order in which processors are triggered. Bigger value means precedence before processors
      * with lower priority.
+     * When two processors have the same priority then order of invocation is undefined.
      */
     default int priority() {
         return Integer.MIN_VALUE;

--- a/runtime/src/main/java/com/tietoevry/quarkus/resteasy/problem/postprocessing/ProblemPostProcessor.java
+++ b/runtime/src/main/java/com/tietoevry/quarkus/resteasy/problem/postprocessing/ProblemPostProcessor.java
@@ -2,7 +2,6 @@ package com.tietoevry.quarkus.resteasy.problem.postprocessing;
 
 import com.tietoevry.quarkus.resteasy.problem.HttpProblem;
 import java.util.Comparator;
-import java.util.function.BiFunction;
 
 /**
  * Post-processors use, change or enhance HttpProblem created by ExceptionMappers via 'apply' method, before they get
@@ -13,10 +12,15 @@ public interface ProblemPostProcessor {
     Comparator<ProblemPostProcessor> DEFAULT_ORDERING = Comparator.comparingInt(ProblemPostProcessor::priority).reversed();
 
     /**
-     * Interceptor method for HttpProblems. In case problem should be changed or enhanced, one can use 'HttpProblem.builder(httpProblem)'.
+     * Interceptor method for HttpProblems. In case problem should be changed or enhanced, one can use
+     * 'HttpProblem.builder(httpProblem)'.
+     * <p>
+     * Should be thread-safe.
+     *
      * @param problem Original HttpProblem, possibly processed by other processors with higher priority.
      * @param context Additional, internal metadata not included in HttpProblem
-     * @return Can be original HttpProblem (for peek-type processors), changed copy or completely new HttpProblem (for map-type processors.
+     * @return Can be original HttpProblem (for peek-type processors), changed copy or completely new HttpProblem (for map-type
+     *         processors.
      */
     HttpProblem apply(HttpProblem problem, ProblemContext context);
 

--- a/runtime/src/main/java/com/tietoevry/quarkus/resteasy/problem/postprocessing/ProblemRecorder.java
+++ b/runtime/src/main/java/com/tietoevry/quarkus/resteasy/problem/postprocessing/ProblemRecorder.java
@@ -2,6 +2,7 @@ package com.tietoevry.quarkus.resteasy.problem.postprocessing;
 
 import com.tietoevry.quarkus.resteasy.problem.ExceptionMapperBase;
 import io.quarkus.runtime.annotations.Recorder;
+import jakarta.enterprise.inject.spi.CDI;
 import java.util.Set;
 
 /**
@@ -22,6 +23,11 @@ public class ProblemRecorder {
 
     public void enableMetrics() {
         ExceptionMapperBase.postProcessorsRegistry.register(new MicroprofileMetricsCollector());
+    }
+
+    public void registerCustomPostProcessors() {
+        CDI.current().select(ProblemPostProcessor.class)
+                .forEach(ExceptionMapperBase.postProcessorsRegistry::register);
     }
 
 }

--- a/runtime/src/test/java/com/tietoevry/quarkus/resteasy/problem/postprocessing/PostProcessorsRegistryTest.java
+++ b/runtime/src/test/java/com/tietoevry/quarkus/resteasy/problem/postprocessing/PostProcessorsRegistryTest.java
@@ -54,7 +54,7 @@ class PostProcessorsRegistryTest {
         }
 
         @Override
-        public HttpProblem apply(HttpProblem problem, ProblemContext problemContext) {
+        public HttpProblem apply(HttpProblem problem, ProblemContext context) {
             invocations.add(priority);
             return problem;
         }


### PR DESCRIPTION
Makes it easy to implement custom `ProblemPostProcessor` by creating a regular CDI bean.
 
Closes #301 (in combination with #311)