### PR TITLE
ConstraintViolationException HTTP status should be configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,9 +181,8 @@ You may also want to check [this article](https://dzone.com/articles/when-http-s
 More on throwing problems: [zalando/problem usage](https://github.com/zalando/problem#usage)
 
 ## Configuration options
-All configuration options are build-time properties, meaning that you cannot override them in the runtime (i.e via environment variables).
 
-- Include MDC properties in the API response (you have to provide those properties to MDC using `MDC.put`)
+- (Build time) Include MDC properties in the API response. You have to provide those properties to MDC using `MDC.put`
 ```
 quarkus.resteasy.problem.include-mdc-properties=uuid,application,version
 ```
@@ -198,7 +197,24 @@ Result:
 }
 ```
 
-- Enable Smallrye (Microprofile) metrics for http error counters. Requires `quarkus-smallrye-metrics` in the classpath.
+- (Runtime) Changes default `400 Bad request` response status when `ConstraintViolationException` is thrown (e.g. by Hibernate Validator)
+```
+quarkus.resteasy.problem.constraint-violation.status=422
+quarkus.resteasy.problem.constraint-violation.title=Constraint violation
+```
+Result:
+```json
+HTTP/1.1 422 Unprocessable Entity
+Content-Type: application/problem+json
+
+{
+    "status": 400,
+    "title": "Constraint violation",
+    (...)
+}
+```
+
+- (Build time) Enable Smallrye (Microprofile) metrics for http error counters. Requires `quarkus-smallrye-metrics` in the classpath.
 
 Please note that if you use `quarkus-micrometer-registry-prometheus` you don't need this feature - http error metrics will be produced regardless of this setting or presence of this extension.
 
@@ -212,7 +228,7 @@ application_http_error_total{status="401"} 3.0
 application_http_error_total{status="500"} 5.0
 ```
 
-- Tuning logging
+- (Runtime) Tuning logging
 ```
 quarkus.log.category.http-problem.level=INFO # default: all problems are logged
 quarkus.log.category.http-problem.level=ERROR # only HTTP 5XX problems are logged

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ HTTP/1.1 422 Unprocessable Entity
 Content-Type: application/problem+json
 
 {
-    "status": 400,
+    "status": 422,
     "title": "Constraint violation",
     (...)
 }

--- a/deployment/src/main/java/com/tietoevry/quarkus/resteasy/problem/deployment/ProblemProcessor.java
+++ b/deployment/src/main/java/com/tietoevry/quarkus/resteasy/problem/deployment/ProblemProcessor.java
@@ -4,6 +4,7 @@ import static com.tietoevry.quarkus.resteasy.problem.deployment.ExceptionMapperD
 import static io.quarkus.deployment.annotations.ExecutionTime.RUNTIME_INIT;
 import static io.quarkus.deployment.annotations.ExecutionTime.STATIC_INIT;
 
+import com.tietoevry.quarkus.resteasy.problem.ProblemRuntimeConfig;
 import com.tietoevry.quarkus.resteasy.problem.postprocessing.ProblemRecorder;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.deployment.Capabilities;
@@ -166,6 +167,12 @@ public class ProblemProcessor {
     @BuildStep
     void registerCustomPostProcessors(ProblemRecorder recorder) {
         recorder.registerCustomPostProcessors();
+    }
+
+    @Record(RUNTIME_INIT)
+    @BuildStep
+    void applyRuntimeConfig(ProblemRecorder recorder, ProblemRuntimeConfig config) {
+        recorder.applyRuntimeConfig(config);
     }
 
     protected Logger logger() {

--- a/integration-test/src/test/java/com/tietoevry/quarkus/resteasy/problem/ConstraintViolationMapperConfigIT.java
+++ b/integration-test/src/test/java/com/tietoevry/quarkus/resteasy/problem/ConstraintViolationMapperConfigIT.java
@@ -1,0 +1,47 @@
+package com.tietoevry.quarkus.resteasy.problem;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+
+@QuarkusTest
+@TestProfile(ConstraintViolationMapperConfigIT.CustomHttpStatus.class)
+class ConstraintViolationMapperConfigIT {
+
+    static {
+        RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+    }
+
+    @Test
+    void constraintViolationShouldProvideErrorDetails() {
+        given()
+                .body("{\"phraseName\": 10 }")
+                .contentType(APPLICATION_JSON)
+                .post("/throw/validation/constraint-violation-exception")
+                .then()
+                .statusCode(422)
+                .body("title", equalTo("Constraint violation"))
+                .body("status", equalTo(422))
+                .body("violations", hasSize(1));
+    }
+
+    public static class CustomHttpStatus implements QuarkusTestProfile {
+
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of(
+                    "quarkus.resteasy.problem.constraint-violation.status", "422",
+                    "quarkus.resteasy.problem.constraint-violation.title", "Constraint violation"
+            );
+        }
+    }
+}

--- a/integration-test/src/test/java/com/tietoevry/quarkus/resteasy/problem/ConstraintViolationMapperConfigNativeIT.java
+++ b/integration-test/src/test/java/com/tietoevry/quarkus/resteasy/problem/ConstraintViolationMapperConfigNativeIT.java
@@ -1,0 +1,7 @@
+package com.tietoevry.quarkus.resteasy.problem;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+class ConstraintViolationMapperConfigNativeIT extends ConstraintViolationMapperConfigIT {
+}

--- a/runtime/src/main/java/com/tietoevry/quarkus/resteasy/problem/ProblemRuntimeConfig.java
+++ b/runtime/src/main/java/com/tietoevry/quarkus/resteasy/problem/ProblemRuntimeConfig.java
@@ -1,0 +1,46 @@
+package com.tietoevry.quarkus.resteasy.problem;
+
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+import io.smallrye.config.WithName;
+
+@ConfigMapping(prefix = "quarkus.resteasy.problem")
+@ConfigRoot(phase = ConfigPhase.RUN_TIME)
+public interface ProblemRuntimeConfig {
+
+    /**
+     * Config for ConstraintViolationException mapper
+     */
+    @WithName("constraint-violation")
+    ConstraintViolationMapperConfig constraintViolation();
+
+    interface ConstraintViolationMapperConfig {
+        static ConstraintViolationMapperConfig defaults() {
+            return new ConstraintViolationMapperConfig() {
+                @Override
+                public int status() {
+                    return 400;
+                }
+
+                @Override
+                public String title() {
+                    return "Bad Request";
+                }
+            };
+        }
+
+        /**
+         * Response status code when ConstraintViolationException is thrown.
+         */
+        @WithDefault("400")
+        int status();
+
+        /**
+         * Response title when ConstraintViolationException is thrown.
+         */
+        @WithDefault("Bad Request")
+        String title();
+    }
+}

--- a/runtime/src/main/java/com/tietoevry/quarkus/resteasy/problem/postprocessing/ProblemRecorder.java
+++ b/runtime/src/main/java/com/tietoevry/quarkus/resteasy/problem/postprocessing/ProblemRecorder.java
@@ -1,6 +1,8 @@
 package com.tietoevry.quarkus.resteasy.problem.postprocessing;
 
 import com.tietoevry.quarkus.resteasy.problem.ExceptionMapperBase;
+import com.tietoevry.quarkus.resteasy.problem.ProblemRuntimeConfig;
+import com.tietoevry.quarkus.resteasy.problem.validation.ConstraintViolationExceptionMapper;
 import io.quarkus.runtime.annotations.Recorder;
 import jakarta.enterprise.inject.spi.CDI;
 import java.util.Set;
@@ -30,4 +32,7 @@ public class ProblemRecorder {
                 .forEach(ExceptionMapperBase.postProcessorsRegistry::register);
     }
 
+    public void applyRuntimeConfig(ProblemRuntimeConfig config) {
+        ConstraintViolationExceptionMapper.configure(config.constraintViolation());
+    }
 }

--- a/runtime/src/main/java/com/tietoevry/quarkus/resteasy/problem/validation/ConstraintViolationExceptionMapper.java
+++ b/runtime/src/main/java/com/tietoevry/quarkus/resteasy/problem/validation/ConstraintViolationExceptionMapper.java
@@ -2,6 +2,7 @@ package com.tietoevry.quarkus.resteasy.problem.validation;
 
 import com.tietoevry.quarkus.resteasy.problem.ExceptionMapperBase;
 import com.tietoevry.quarkus.resteasy.problem.HttpProblem;
+import com.tietoevry.quarkus.resteasy.problem.ProblemRuntimeConfig.ConstraintViolationMapperConfig;
 import jakarta.annotation.Priority;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
@@ -13,7 +14,6 @@ import jakarta.ws.rs.Priorities;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.container.ResourceInfo;
 import jakarta.ws.rs.core.Context;
-import jakarta.ws.rs.core.Response;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.util.ArrayList;
@@ -31,14 +31,20 @@ import java.util.stream.Stream;
 @Priority(Priorities.USER)
 public final class ConstraintViolationExceptionMapper extends ExceptionMapperBase<ConstraintViolationException> {
 
+    private static ConstraintViolationMapperConfig config = ConstraintViolationMapperConfig.defaults();
+
     @Context
     ResourceInfo resourceInfo;
+
+    public static void configure(ConstraintViolationMapperConfig config) {
+        ConstraintViolationExceptionMapper.config = config;
+    }
 
     @Override
     protected HttpProblem toProblem(ConstraintViolationException exception) {
         return HttpProblem.builder()
-                .withStatus(Response.Status.BAD_REQUEST)
-                .withTitle(Response.Status.BAD_REQUEST.getReasonPhrase())
+                .withStatus(config.status())
+                .withTitle(config.title())
                 .with("violations", toViolations(exception.getConstraintViolations()))
                 .build();
     }


### PR DESCRIPTION
Turns out `HttpProblem` relied on `Response.Status` a bit too much, which is being addressed in #314 

Closes #273

