### PR TITLE
Reduce HttpProblem dependency on Response.StatusType to the minimum

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ or add your own suggestions and start discussion. Then create fork or branch and
 Quarkus has a strictly enforced code style, so as this extension. Code formatting is done by the Eclipse code formatter, using the config files
 found in the `ide-config` directory. By default when you run `./mvnw install` the code will be formatted automatically.
 
-If you want to run the formatting without doing a full build, you can run `./mvnw process-sources`.
+If you want to run the formatting without doing a full build, you can run `./mvnw process-sources` or `./mvnw formatter:format`.
 
 More details on how to setup your ide can be found in official [Quarkus Contributing guide](https://github.com/quarkusio/quarkus/blob/main/CONTRIBUTING.md#ide-config-and-code-style)
 
@@ -26,10 +26,10 @@ Everything in this extension revolves around `ExceptionMapperBase` abstract clas
 exception mappers extending this class.
 
 Exception lifecycle:
-1. JaxRS implementation (RESTeasy) catches exception, and immediately looks for best matching `ExceptionMapper`. Hopefully it will be one of our mappers :)
-2. `ExceptionMapperBase::toResponse` method is called, where original exception is turned into `HttpProblem` object by a specific subclass mapper (e.g `WebApplicationExceptionMapper`).
-3. `Problem` goes into post-processing phase to apply logging, metrics generation, MCD properties injection etc.
-4. Enhanced `Problem` is turned into JaxRS `Response` object, with `Problem` object placed as entity (response body). This is where `ExceptionMapper` work is finished.
+1. JaxRS/JakartaRS implementation (RESTeasy) catches exception, and immediately looks for best matching `ExceptionMapper`. Hopefully it will be one of our mappers :)
+2. `ExceptionMapperBase::toResponse` method is called, where original exception is turned into `HttpProblem` object by the specific subclass mapper (e.g `WebApplicationExceptionMapper`).
+3. `HttpProblem` goes into post-processing phase to apply logging, metrics generation, MCD properties injection etc.
+4. Enhanced `HttpProblem` is turned into JaxRS/JakartaRS `Response` object, with `HttpProblem` object placed as entity (response body). This is where `ExceptionMapper` work is finished.
 5. RESTeasy serializes `Response` object into raw HTTP response, with little help from our JSON serializer (either `JacksonProblemSerializer` or `JsonBProblemSerializer`)
 6. End user gets nice `application/problem+json` HTTP response.
 

--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.tietoevry.quarkus</groupId>
         <artifactId>quarkus-resteasy-problem-parent</artifactId>
-        <version>3.0.1-SNAPSHOT</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>quarkus-resteasy-problem-deployment</artifactId>

--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -5,14 +5,14 @@
     <parent>
         <groupId>com.tietoevry.quarkus</groupId>
         <artifactId>quarkus-resteasy-problem-parent</artifactId>
-        <version>3.0.1-SNAPSHOT</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>quarkus-resteasy-problem-integration-test</artifactId>
     <name>Quarkus - RESTeasy - Problem - Integration Tests</name>
 
     <properties>
-        <quarkus-resteasy-problem.version>3.0.1-SNAPSHOT</quarkus-resteasy-problem.version>
+        <quarkus-resteasy-problem.version>3.1.0-SNAPSHOT</quarkus-resteasy-problem.version>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.tietoevry.quarkus</groupId>
     <artifactId>quarkus-resteasy-problem-parent</artifactId>
-    <version>3.0.1-SNAPSHOT</version>
+    <version>3.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Quarkus - RESTeasy - Problem - Parent</name>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.tietoevry.quarkus</groupId>
         <artifactId>quarkus-resteasy-problem-parent</artifactId>
-        <version>3.0.1-SNAPSHOT</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>quarkus-resteasy-problem</artifactId>

--- a/runtime/src/main/java/com/tietoevry/quarkus/resteasy/problem/ExceptionMapperBase.java
+++ b/runtime/src/main/java/com/tietoevry/quarkus/resteasy/problem/ExceptionMapperBase.java
@@ -6,7 +6,6 @@ import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
 import jakarta.ws.rs.ext.ExceptionMapper;
-import java.util.Objects;
 
 /**
  * Base class for all ExceptionMappers in this extension, takes care of mapping Exceptions to Problems, triggering
@@ -22,8 +21,6 @@ public abstract class ExceptionMapperBase<E extends Throwable> implements Except
     @Override
     public final Response toResponse(E exception) {
         HttpProblem problem = toProblem(exception);
-        Objects.requireNonNull(problem.getStatus(), "Status must not be null");
-
         ProblemContext context = ProblemContext.of(exception, uriInfo);
         HttpProblem finalProblem = postProcessorsRegistry.applyPostProcessing(problem, context);
         return finalProblem.toResponse();

--- a/runtime/src/main/java/com/tietoevry/quarkus/resteasy/problem/HttpProblem.java
+++ b/runtime/src/main/java/com/tietoevry/quarkus/resteasy/problem/HttpProblem.java
@@ -99,7 +99,9 @@ public class HttpProblem extends RuntimeException {
         return this.statusCode;
     }
 
-    @Deprecated(forRemoval = true)
+    /**
+     * Returns null if status code has no representation in Response.Status enum.
+     */
     public Response.StatusType getStatus() {
         return Response.Status.fromStatusCode(statusCode);
     }

--- a/runtime/src/main/java/com/tietoevry/quarkus/resteasy/problem/jackson/JacksonProblemSerializer.java
+++ b/runtime/src/main/java/com/tietoevry/quarkus/resteasy/problem/jackson/JacksonProblemSerializer.java
@@ -27,9 +27,8 @@ public final class JacksonProblemSerializer extends StdSerializer<HttpProblem> {
         if (problem.getType() != null) {
             json.writeStringField("type", problem.getType().toASCIIString());
         }
-        if (problem.getStatus() != null) {
-            json.writeNumberField("status", problem.getStatus().getStatusCode());
-        }
+        json.writeNumberField("status", problem.getStatusCode());
+
         if (problem.getTitle() != null) {
             json.writeStringField("title", problem.getTitle());
         }

--- a/runtime/src/main/java/com/tietoevry/quarkus/resteasy/problem/jsonb/JsonbProblemSerializer.java
+++ b/runtime/src/main/java/com/tietoevry/quarkus/resteasy/problem/jsonb/JsonbProblemSerializer.java
@@ -16,9 +16,8 @@ public final class JsonbProblemSerializer implements JsonbSerializer<HttpProblem
         if (problem.getType() != null) {
             generator.write("type", problem.getType().toASCIIString());
         }
-        if (problem.getStatus() != null) {
-            generator.write("status", problem.getStatus().getStatusCode());
-        }
+        generator.write("status", problem.getStatusCode());
+
         if (problem.getTitle() != null) {
             generator.write("title", problem.getTitle());
         }

--- a/runtime/src/main/java/com/tietoevry/quarkus/resteasy/problem/postprocessing/MicroprofileMetricsCollector.java
+++ b/runtime/src/main/java/com/tietoevry/quarkus/resteasy/problem/postprocessing/MicroprofileMetricsCollector.java
@@ -2,7 +2,6 @@ package com.tietoevry.quarkus.resteasy.problem.postprocessing;
 
 import com.tietoevry.quarkus.resteasy.problem.HttpProblem;
 import io.smallrye.metrics.MetricRegistries;
-import java.util.Objects;
 import org.eclipse.microprofile.metrics.Metadata;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.eclipse.microprofile.metrics.Tag;
@@ -45,9 +44,7 @@ final class MicroprofileMetricsCollector implements ProblemPostProcessor {
 
     @Override
     public HttpProblem apply(HttpProblem problem, ProblemContext context) {
-        Objects.requireNonNull(problem.getStatus());
-
-        Tag tag = new Tag(STATUS_TAG, String.valueOf(problem.getStatus().getStatusCode()));
+        Tag tag = new Tag(STATUS_TAG, String.valueOf(problem.getStatusCode()));
         registry.counter(METRIC_NAME, tag).inc();
 
         return problem;

--- a/runtime/src/main/java/com/tietoevry/quarkus/resteasy/problem/postprocessing/ProblemLogger.java
+++ b/runtime/src/main/java/com/tietoevry/quarkus/resteasy/problem/postprocessing/ProblemLogger.java
@@ -26,9 +26,7 @@ final class ProblemLogger implements ProblemPostProcessor {
             return problem;
         }
 
-        Objects.requireNonNull(problem.getStatus());
-
-        if (problem.getStatus().getStatusCode() >= 500) {
+        if (problem.getStatusCode() >= 500) {
             if (logger.isErrorEnabled()) {
                 logger.error(serialize(problem), context.cause);
             }
@@ -42,7 +40,7 @@ final class ProblemLogger implements ProblemPostProcessor {
 
     private String serialize(HttpProblem problem) {
         Stream<String> basicFields = Stream.of(
-                (problem.getStatus() == null) ? null : ("status=" + problem.getStatus().getStatusCode()),
+                ("status=" + problem.getStatusCode()),
                 (problem.getTitle() == null) ? null : ("title=\"" + problem.getTitle() + "\""),
                 (problem.getDetail() == null) ? null : ("detail=\"" + problem.getDetail() + "\""),
                 (problem.getInstance() == null) ? null : ("instance=\"" + problem.getInstance() + "\""),

--- a/runtime/src/test/java/com/tietoevry/quarkus/resteasy/problem/HttpProblemTest.java
+++ b/runtime/src/test/java/com/tietoevry/quarkus/resteasy/problem/HttpProblemTest.java
@@ -17,7 +17,7 @@ class HttpProblemTest {
 
         assertThat(problem.getType()).hasHost("tietoevry.com").hasPath("/problem");
         assertThat(problem.getInstance()).hasPath("/endpoint");
-        assertThat(problem.getStatus().getStatusCode()).isEqualTo(400);
+        assertThat(problem.getStatusCode()).isEqualTo(400);
         assertThat(problem.getDetail()).isEqualTo("Deep down wrongness, zażółć gęślą jaźń for Håkensth");
         assertThat(problem.getHeaders())
                 .containsEntry("X-Numeric-Header", 123)

--- a/runtime/src/test/java/com/tietoevry/quarkus/resteasy/problem/postprocessing/MdcPropertiesInjectorTest.java
+++ b/runtime/src/test/java/com/tietoevry/quarkus/resteasy/problem/postprocessing/MdcPropertiesInjectorTest.java
@@ -34,7 +34,7 @@ class MdcPropertiesInjectorTest {
         HttpProblem enhancedProblem = processor.apply(badRequestProblem(), simpleContext());
 
         assertThat(enhancedProblem.getTitle()).isEqualTo("There's something wrong with your request");
-        assertThat(enhancedProblem.getStatus()).isEqualTo(BAD_REQUEST);
+        assertThat(enhancedProblem.getStatusCode()).isEqualTo(BAD_REQUEST.getStatusCode());
     }
 
     @Test


### PR DESCRIPTION
This will allow some certain future features to be much easier to implement, it also reduces non-null checks as we're relying on `int` status code, not nullable `Response.StatusType`